### PR TITLE
Fix incompatibility with Bee Angry-est, replace ${version} during build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,19 @@ dependencies {
 	modCompile "io.github.prospector:modmenu:${project.mod_menu_version}"
 }
 
+processResources {
+	inputs.property "version", project.version
+
+	from(sourceSets.main.resources.srcDirs) {
+		include "fabric.mod.json"
+		expand "version": project.version
+	}
+
+	from(sourceSets.main.resources.srcDirs) {
+		exclude "fabric.mod.json"
+	}
+}
+
 idea {
 	module {
 		inheritOutputDirs = false


### PR DESCRIPTION
The fixing part isn't necessarily needed after a5dd504, but an `@Inject` should be more compatible. I also added a replacement for the `${version}` in the fabric.mod.json so it gets the proper version during build.