### PR TITLE
Fix criterion for "Painful Sting" advancement

### DIFF
--- a/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
+++ b/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
@@ -21,7 +21,7 @@
       "conditions": {
         "killing_blow": {
           "source_entity": {
-           "equipment": {
+            "equipment": {
               "mainhand": {
                 "items": [
                   "beebetter:bee_stinger"

--- a/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
+++ b/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
@@ -21,7 +21,13 @@
       "conditions": {
         "killing_blow": {
           "source_entity": {
-            "nbt": "{SelectedItem:{id:\"beebetter:bee_stinger\"}}"
+           "equipment": {
+              "mainhand": {
+                "items": [
+                  "beebetter:bee_stinger"
+                ]
+              }
+            }
           }
         }
       }

--- a/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
+++ b/src/main/resources/data/minecraft/advancements/adventure/bee_stinger_kill.json
@@ -21,11 +21,7 @@
       "conditions": {
         "killing_blow": {
           "source_entity": {
-            "equipment": {
-              "mainhand": {
-                "item": "beebetter:bee_stinger"
-              }
-            }
+            "nbt": "{SelectedItem:{id:\"beebetter:bee_stinger\"}}"
           }
         }
       }


### PR DESCRIPTION
I noticed that "Painful Sting" was being granted when I killed a mob with *any* weapon. This seems to fix it so that it only triggers as intended.